### PR TITLE
Stop reopening the geocode reminder for two shops that never resolve

### DIFF
--- a/.github/workflows/update_map.yml
+++ b/.github/workflows/update_map.yml
@@ -133,8 +133,11 @@ jobs:
           MISSING=$(python - <<'PY'
           import json
           from pathlib import Path
+
+          from src.geocode_gaps import count_actionable_place_id_gaps
+
           data = json.loads(Path("data/current_list.json").read_text(encoding="utf-8"))
-          print(sum(1 for row in data if not row.get("place_id")))
+          print(count_actionable_place_id_gaps(data))
           PY
           )
           echo "missing=$MISSING" >> "$GITHUB_OUTPUT"

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -46,7 +46,10 @@ workflow that pushes to main.
 9. **Commit + Pages deploy** — bot commits `data/`, `output/`, `site/`; a
    browser-key rebuild runs only when the `GOOGLE_MAPS_JS_API_KEY` secret exists.
 10. **Auto-issue** — if shops are missing `place_id`, the workflow opens
-   "Owner geocode refresh needed (N shops missing place_id)".
+   "Owner geocode refresh needed (N shops missing place_id)". Two shops that
+   have never resolved are exempt via `src/geocode_gaps.py`, so the reminder
+   only fires for a gap a geocode run could actually close. Delete an entry
+   there the moment a run resolves it.
 
 ## Playbooks
 
@@ -56,7 +59,9 @@ shrank, re-run with `SCRAPE_ALLOW_SHRINK=1` locally, inspect the diff, push.
 If the layout changed, fix the parsers in `src/scraper.py` (legacy `<li>`
 parser first, Elementor loop-card parser second) against saved HTML.
 
-**Geocode reminder issue opened** — run locally with the owner key
+**Geocode reminder issue opened** — a shop that is not on the
+`src/geocode_gaps.py` accept list is missing its place_id. Run locally with the
+owner key
 (never commit it; it lives in `.env`):
 `python src/main.py owner-geocode --api-key "$GOOGLE_MAPS_API_KEY"`,
 then commit `data/current_list.json`. Annual cost ~$3.40, inside free tier.

--- a/src/geocode_gaps.py
+++ b/src/geocode_gaps.py
@@ -1,0 +1,34 @@
+"""Which missing place_ids still count as a gap worth chasing.
+
+`update_map.yml` opens a reminder issue whenever a shop has no `place_id`.
+Two shops have never resolved across repeated owner-geocode runs, so that
+reminder reopened on every schedule and stopped carrying information. They are
+accepted as-is: both still render in the list with the address the source
+publishes and a working Google Maps link, and Little Victories keeps its pin
+from the coordinates it already has.
+"""
+
+from __future__ import annotations
+
+from src.category_utils import normalize_category
+
+# (category, rank) of shops accepted without a place_id. Remove an entry here
+# the moment a geocode run resolves it, so the reminder starts working again.
+ACCEPTED_WITHOUT_PLACE_ID: frozenset[tuple[str, int]] = frozenset(
+    {
+        ("Top 100", 71),  # Little Victories Coffee, Ottawa — has coordinates, no place_id
+        ("Top 100", 100),  # Vacation Coffee, Melbourne — no coordinates either
+    }
+)
+
+
+def count_actionable_place_id_gaps(rows: list[dict[str, object]]) -> int:
+    """Shops missing a place_id that an owner-geocode run could still fix."""
+    return sum(1 for row in rows if _is_actionable_gap(row))
+
+
+def _is_actionable_gap(row: dict[str, object]) -> bool:
+    if row.get("place_id"):
+        return False
+    key = (normalize_category(str(row.get("category", ""))), int(row.get("rank", 0)))
+    return key not in ACCEPTED_WITHOUT_PLACE_ID

--- a/tests/test_geocode_gaps.py
+++ b/tests/test_geocode_gaps.py
@@ -1,0 +1,37 @@
+from src.geocode_gaps import ACCEPTED_WITHOUT_PLACE_ID, count_actionable_place_id_gaps
+
+
+def test_accepted_shops_do_not_count_as_a_gap() -> None:
+    rows = [
+        {"category": "Top 100", "rank": 71, "name": "Little Victories Coffee", "place_id": None},
+        {"category": "Top 100", "rank": 100, "name": "Vacation Coffee", "place_id": ""},
+    ]
+
+    assert count_actionable_place_id_gaps(rows) == 0
+
+
+def test_a_new_missing_place_id_still_counts() -> None:
+    rows = [
+        {"category": "Top 100", "rank": 71, "name": "Little Victories Coffee", "place_id": None},
+        {"category": "South America", "rank": 5, "name": "Somewhere New", "place_id": None},
+    ]
+
+    assert count_actionable_place_id_gaps(rows) == 1
+
+
+def test_resolved_shops_never_count() -> None:
+    rows = [{"category": "Top 100", "rank": 1, "name": "Onyx Coffee LAB", "place_id": "abc123"}]
+
+    assert count_actionable_place_id_gaps(rows) == 0
+
+
+def test_category_spelling_variants_still_match_the_accept_list() -> None:
+    rows = [{"category": "top 100", "rank": 100, "name": "Vacation Coffee", "place_id": None}]
+
+    assert count_actionable_place_id_gaps(rows) == 0
+
+
+def test_accept_list_stays_small() -> None:
+    """A growing list means geocoding is quietly degrading, not that more shops
+    are legitimately unresolvable."""
+    assert len(ACCEPTED_WITHOUT_PLACE_ID) <= 5


### PR DESCRIPTION
## Why

`update_map.yml` opens "Owner geocode refresh needed (N shops missing place_id)" whenever any shop lacks a `place_id`. Two shops have never resolved across repeated owner-geocode runs, so that issue has reopened on **every** schedule — #28, #24, #23, #22, #21, #19 are all the same two shops — and stopped carrying any signal.

Per the decision to accept these rather than keep tracking them as a defect:

| shop | state | user-visible result |
|---|---|---|
| Little Victories Coffee (Top 100 #71) | has coordinates, no `place_id` | pin renders normally |
| Vacation Coffee (Top 100 #100) | no coordinates either | listed with address + working Maps link, no pin |

## What changed

- New `src/geocode_gaps.py` holds the accept list and `count_actionable_place_id_gaps()`.
- The workflow's counting step calls it, so the reminder fires only for a gap a geocode run could actually close. **It does not suppress the issue outright** — a newly unresolved shop still opens one.
- `docs/RUNBOOK.md` documents the list and says to delete an entry the moment a run resolves it.

## Guardrail

A test caps the accept list at five entries, so a real geocoding regression surfaces instead of being quietly absorbed by a growing exemption list.

`pytest`: 87 passed (5 new).

https://claude.ai/code/session_01BmEN9XQNAn2nuB5SF9892m